### PR TITLE
Modification of the BSI Version 1

### DIFF
--- a/bsi_flex_335_v1_0/sapient_message.proto
+++ b/bsi_flex_335_v1_0/sapient_message.proto
@@ -10,7 +10,7 @@ import "sapient_msg/bsi_flex_335_v1_0/alert.proto";
 import "sapient_msg/bsi_flex_335_v1_0/alert_ack.proto";
 import "sapient_msg/bsi_flex_335_v1_0/detection_report.proto";
 import "sapient_msg/bsi_flex_335_v1_0/error.proto";
-import "sapient_msg/bsi_flex_335_v1_0/proto_options.proto";
+import "sapient_msg/proto_options.proto";
 import "sapient_msg/bsi_flex_335_v1_0/registration.proto";
 import "sapient_msg/bsi_flex_335_v1_0/registration_ack.proto";
 import "sapient_msg/bsi_flex_335_v1_0/status_report.proto";


### PR DESCRIPTION
We have defined proto_options.proto as generic for BSI Version 1 and BSI Version 2 and for future version.

However I discover a discordance between BSI Version 1 & 2 regarding the import definition (located in the sapient_message.proto).
The BSI Version was not aligned with the definition.
`sapient_msg/bsi_flex_335_v1/proto_options.proto` become `sapient_msg/proto_options.proto`

That's will also impacting generated file to ensure that the structure will become correct regarding :
..\sapient_msg\proto_options
..\sapient_msg\bsi_flex_335_v1_0\sapient_message.
..\sapient_msg\bsi_flex_335_v2_0\sapient_message.

(this issue was discovered during the compilation of the python files). The generated folders provides for bsi flex 335 v1.0 the proto_options was inside of the bsi_flex_335_v1_0 folder **, which is not correct,** and for the bsi flex 335 v2.0 the proto_options was under sapient_msg **,which is correct,** regarding initial definition.